### PR TITLE
Hot fix for salobj renaming of makeAckCmd -> make_ackcmd.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,118 @@
+pipeline {
+    agent any
+    options {
+      disableConcurrentBuilds()
+    }
+    environment {
+        network_name = "n_${BUILD_ID}_${JENKINS_NODE_COOKIE}"
+        container_name = "c_${BUILD_ID}_${JENKINS_NODE_COOKIE}"
+        work_branches = "${GIT_BRANCH} ${CHANGE_BRANCH} develop"
+        LSST_IO_CREDS = credentials("lsst-io")
+    }
+
+    stages {
+        stage("Pulling docker image") {
+            steps {
+                script {
+                    sh """
+                    docker pull lsstts/salobj:develop
+                    """
+                }
+            }
+        }
+        stage("Preparing environment") {
+            steps {
+                script {
+                    sh """
+                    docker network create \${network_name}
+                    chmod -R a+rw \${WORKSPACE}
+                    container=\$(docker run -v \${WORKSPACE}:/home/saluser/repo/ -td --rm --net \${network_name} -e LTD_USERNAME=\${LSST_IO_CREDS_USR} -e LTD_PASSWORD=\${LSST_IO_CREDS_PSW} --name \${container_name} lsstts/salobj:develop)
+                    """
+                }
+            }
+        }
+        stage("Checkout sal") {
+            steps {
+                script {
+                    sh """
+                    docker exec -u saluser \${container_name} sh -c \"source ~/.setup.sh && cd /home/saluser/repos/ts_sal && /home/saluser/.checkout_repo.sh \${work_branches} && git pull\"
+                    """
+                }
+            }
+        }
+        stage("Checkout salobj") {
+            steps {
+                script {
+                    sh """
+                    docker exec -u saluser \${container_name} sh -c \"source ~/.setup.sh && cd /home/saluser/repos/ts_salobj && /home/saluser/.checkout_repo.sh \${work_branches} && git pull\"
+                    """
+                }
+            }
+        }
+        stage("Checkout xml") {
+            steps {
+                script {
+                    sh """
+                    docker exec -u saluser \${container_name} sh -c \"source ~/.setup.sh && cd /home/saluser/repos/ts_xml && /home/saluser/.checkout_repo.sh \${work_branches} && git pull\"
+                    """
+                }
+            }
+        }
+        stage("Checkout IDL") {
+            steps {
+                script {
+                    sh """
+                    docker exec -u saluser \${container_name} sh -c \"source ~/.setup.sh && cd /home/saluser/repos/ts_idl && /home/saluser/.checkout_repo.sh \${work_branches} && git pull\"
+                    """
+                }
+            }
+        }
+        stage("Build IDL files") {
+            steps {
+                script {
+                    sh """
+                    docker exec -u saluser \${container_name} sh -c \"source ~/.setup.sh && make_idl_files.py ScriptQueue Script\"
+                    """
+                }
+            }
+        }
+        stage("Running tests") {
+            steps {
+                script {
+                    sh """
+                    docker exec -u saluser \${container_name} sh -c \"source ~/.setup.sh && cd /home/saluser/repo/ && eups declare -r . -t saluser && setup ts_scriptqueue -t saluser && export LSST_DDS_IP=192.168.0.1 && printenv LSST_DDS_IP && pytest --color=no --junitxml=tests/.tests/junit.xml\"
+                    """
+                }
+            }
+        }
+    }
+    post {
+        always {
+            // The path of xml needed by JUnit is relative to
+            // the workspace.
+            junit 'tests/.tests/junit.xml'
+
+            // Publish the HTML report
+            publishHTML (target: [
+                allowMissing: false,
+                alwaysLinkToLastBuild: false,
+                keepAll: true,
+                reportDir: 'tests/.tests/',
+                reportFiles: 'index.html',
+                reportName: "Coverage Report"
+              ])
+
+              sh """
+              docker exec -u saluser \${container_name} sh -c \"source ~/.setup.sh && cd /home/saluser/repo/ && setup ts_scriptqueue -t saluser && package-docs build && ltd upload --product ts-scriptqueue --git-ref \${GIT_BRANCH} --dir doc/_build/html\"
+              """
+        }
+        cleanup {
+            sh """
+                docker exec -u root --privileged \${container_name} sh -c \"chmod -R a+rw /home/saluser/repo/ \"
+                docker stop \${container_name} || echo Could not stop container
+                docker network rm \${network_name} || echo Could not remove network
+            """
+            deleteDir()
+        }
+    }
+}

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,19 @@
 Version History
 ###############
 
+v2.6.1
+======
+
+Salobj 6 changed the name of the ``SalInfo.makeAckCmd`` method to ``SalInfo.make_ackcmd``.
+Add a check to make sure ``SalInfo`` has a ``make_ackcmd`` attribute and use ``makeAckCmd`` if not.
+
+Changes:
+
+* Add backward compatibility between salobj 5 and 6.
+* Add Jenkinsfile for CI job.
+* In test_utils.py separate testing ``get_scripts_dir`` from standard and external scripts.
+  Since packages are optional, skip tests if packages cannot be imported.
+
 v2.6.0
 ======
 

--- a/python/lsst/ts/scriptqueue/script_queue.py
+++ b/python/lsst/ts/scriptqueue/script_queue.py
@@ -324,7 +324,17 @@ class ScriptQueue(salobj.BaseCsc):
             location=data.location,
             location_sal_index=data.locationSalIndex,
         )
-        return self.salinfo.makeAckCmd(
+
+        # Backward compatibility between salobj 5 and 6.
+        # TODO: (DM-26134) Remove this when salobj 6 is released and 5 is
+        # retired.
+        make_ackcmd = (
+            self.salinfo.make_ackcmd
+            if hasattr(self.salinfo, "make_ackcmd")
+            else self.salinfo.makeAckCmd
+        )
+
+        return make_ackcmd(
             private_seqNum=data.private_seqNum,
             ack=salobj.SalRetCode.CMD_COMPLETE,
             result=str(script_info.index),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,8 +23,15 @@ import os
 import pathlib
 import unittest
 
-from lsst.ts import standardscripts
-from lsst.ts import externalscripts
+try:
+    from lsst.ts import standardscripts
+except ImportError:
+    standardscripts = None
+
+try:
+    from lsst.ts import externalscripts
+except ImportError:
+    externalscripts = None
 from lsst.ts import scriptqueue
 
 
@@ -43,12 +50,15 @@ class UtilsTestCase(unittest.TestCase):
         )
         self.assertEqual(set(scripts), expectedscripts)
 
-    def test_get_default_scripts_dir(self):
+    @unittest.skipIf(standardscripts is None, "Could not import ts_standardscripts")
+    def test_get_default_standard_scripts_dir(self):
         standard_dir = scriptqueue.get_default_scripts_dir(is_standard=True)
         self.assertIsInstance(standard_dir, pathlib.Path)
         self.assertTrue(standard_dir.samefile(standardscripts.get_scripts_dir()))
         self.assertEqual(standard_dir.name, "scripts")
 
+    @unittest.skipIf(externalscripts is None, "Could not import ts_externalscripts")
+    def test_get_default_external_scripts_dir(self):
         external_dir = scriptqueue.get_default_scripts_dir(is_standard=False)
         self.assertIsInstance(external_dir, pathlib.Path)
         self.assertTrue(external_dir.samefile(externalscripts.get_scripts_dir()))


### PR DESCRIPTION
Salobj 6 changed the name of the `SalInfo.makeAckCmd` method to `SalInfo.make_ackcmd`.
Add a check to make sure `SalInfo` has a `make_ackcmd` attribute and use `makeAckCmd` if not.
Add Jenkinsfile for CI job.
In test_utils.py separate testing `get_scripts_dir` from standard and external scripts.
Since packages are optional, skip tests if packages cannot be imported.